### PR TITLE
Modernize CUDA build for gReg3D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,18 @@
-cmake_minimum_required(VERSION 2.8)
-find_package(CUDA QUIET REQUIRED)
+cmake_minimum_required(VERSION 3.18)
+project(greg3d LANGUAGES C CXX CUDA)
+
+find_package(CUDAToolkit REQUIRED)
+
 set(CMAKE_BUILD_TYPE Release)
-set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -gencode arch=compute_35,code=sm_35)
+
+# Enable C++14 for both host and device code
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+# Build for a modern architecture (sm_70 and newer are supported by recent CUDA)
+set(CMAKE_CUDA_ARCHITECTURES 70)
 include_directories(
     GDelaunay/Common
     GDelaunay/GDelaunay
@@ -38,7 +49,5 @@ set(GREG3D_SOURCE_FILES
     GDelaunay/PBA/Pba.cu
     GDelaunay/PBA/Pba.h
     )
-cuda_add_executable(
-    greg3d
-    ${GREG3D_SOURCE_FILES}
-    )
+add_executable(greg3d ${GREG3D_SOURCE_FILES})
+target_link_libraries(greg3d PRIVATE CUDA::cudart)

--- a/GDelaunay/GDelaunay/GDelHost.cu
+++ b/GDelaunay/GDelaunay/GDelHost.cu
@@ -44,6 +44,8 @@ DAMAGE.
 #include "GDelInternal.h"
 #include "GDelKernels.h"
 
+#include <thrust/tuple.h>
+
 using namespace std;
 
 const int ThreadsPerBlock   = MAX_THREADS_PER_BLOCK;
@@ -182,7 +184,9 @@ public:
                 containerTimer.start(); 
             }
 
-            _ptr = thrust::device_malloc< T >( _capacity );
+            T* raw = nullptr;
+            CudaSafeCall( cudaMalloc( &raw, _capacity * sizeof( T ) ) );
+            _ptr = thrust::device_pointer_cast( raw );
 
             if ( LogMemory )
             {
@@ -1477,9 +1481,9 @@ int __makeFacetList()
 
     if ( facetNum > ThreadNum )
         thrust::sort_by_key(    DFacetData._vertStarVec->begin(),  DFacetData._vertStarVec->end(),
-                                thrust::make_zip_iterator( make_tuple(  DFacetData._fromStarVec->begin(),
-                                                                        DFacetData._fromTriVec->begin(),
-                                                                        DFacetData._segVec->begin() ) ) );
+                                thrust::make_zip_iterator( thrust::make_tuple(  DFacetData._fromStarVec->begin(),
+                                                                                DFacetData._fromTriVec->begin(),
+                                                                                DFacetData._segVec->begin() ) ) );
 
     return facetNum;
 }

--- a/GDelaunay/PBA/pba3DKernel.h
+++ b/GDelaunay/PBA/pba3DKernel.h
@@ -32,6 +32,8 @@ DAMAGE.
 
 #define TOID(x, y, z, w)    (__mul24(__mul24(z, w) + (y), w) + (x))
 
+#define tex1Dfetch(tex, idx) tex[idx]
+
 // Rotate (X, Y, Z) to (Y, X, Z)
 #define ROTATEXY(x)   ((((x) & 0xffc00) << 10) | \
                        (((x) & 0x3ff00000) >> 10) | \
@@ -233,8 +235,8 @@ __global__ void kernelMaurerAxis(int *stack, int size, int mod, int bandSize)
     int ty = band * bandSize; 
     int tz = blockIdx.y * blockDim.y + threadIdx.y; 
 
-    int lastY = INFINITY; 
-    int stackX_1, stackY_1 = INFINITY, stackZ_1, stackX_2, stackY_2 = INFINITY, stackZ_2; 
+    int lastY = PBA_INFINITY; 
+    int stackX_1, stackY_1 = PBA_INFINITY, stackZ_1, stackX_2, stackY_2 = PBA_INFINITY, stackZ_2; 
     int p = MARKER;
     int nx, ny, nz, s1, s2; 
     float i1, i2;     
@@ -243,7 +245,7 @@ __global__ void kernelMaurerAxis(int *stack, int size, int mod, int bandSize)
         p = tex1Dfetch(pbaTexColor, TOID(tx, ty, tz, size));
 
         if (p != MARKER) {
-            while (stackY_2 != INFINITY) {
+            while (stackY_2 != PBA_INFINITY) {
                 DECODE(s1, stackX_1, stackY_1, stackZ_1); 
                 DECODE(s2, stackX_2, stackY_2, stackZ_2); 
                 i1 = interpointY(stackX_1, stackY_2, stackZ_1, stackX_2, lastY, stackZ_2, tx, tz); 
@@ -255,7 +257,7 @@ __global__ void kernelMaurerAxis(int *stack, int size, int mod, int bandSize)
 
                 lastY = stackY_2; s2 = s1; stackY_2 = stackY_1;
 
-                if (stackY_2 != INFINITY)
+                if (stackY_2 != PBA_INFINITY)
                     s1 = stack[TOID(tx, stackY_2, tz, size)]; 
             }
 
@@ -268,7 +270,7 @@ __global__ void kernelMaurerAxis(int *stack, int size, int mod, int bandSize)
     }
 
     if (p == MARKER) 
-        stack[TOID(tx, ty-1, tz, size)] = ENCODE(INFINITY, lastY, INFINITY); 
+        stack[TOID(tx, ty-1, tz, size)] = ENCODE(PBA_INFINITY, lastY, PBA_INFINITY); 
 }
 
 __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, int bandSize) 
@@ -291,16 +293,16 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
     p = tex1Dfetch(pbaTexLinks, TOID(tx, lastY, tz, size)); 
     DECODE(p, stack_2.x, stack_2.y, stack_2.z); 
 
-    if (stack_2.x == INFINITY) {     // Not a site
+    if (stack_2.x == PBA_INFINITY) {     // Not a site
         lastY = stack_2.y; 
 
-        if (lastY != INFINITY) {
+        if (lastY != PBA_INFINITY) {
             p = tex1Dfetch(pbaTexLinks, TOID(tx, lastY, tz, size)); 
             DECODE(p, stack_2.x, stack_2.y, stack_2.z); 
         }
     }   
 
-    if (stack_2.y != INFINITY) {
+    if (stack_2.y != PBA_INFINITY) {
         p = tex1Dfetch(pbaTexLinks, TOID(tx, stack_2.y, tz, size)); 
         DECODE(p, stack_1.x, stack_1.y, stack_1.z); 
     }
@@ -311,7 +313,7 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
     if (next < 0)       // Not a site
         firstY = -next; 
 
-    if (firstY != INFINITY) {
+    if (firstY != PBA_INFINITY) {
         id = TOID(tx, firstY, tz, size); 
         p = tex1Dfetch(pbaTexLinks, id); 
         DECODE(p, current.x, current.y, current.z); 
@@ -319,8 +321,8 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
 
     int top = 0; 
 
-    while (top < 2 && firstY != INFINITY) {
-        while (stack_2.y != INFINITY) {
+    while (top < 2 && firstY != PBA_INFINITY) {
+        while (stack_2.y != PBA_INFINITY) {
             i1 = interpointY(stack_1.x, stack_2.y, stack_1.z, stack_2.x, lastY, stack_2.z, tx, tz); 
             i2 = interpointY(stack_2.x, lastY, stack_2.z, current.x, firstY, current.z, tx, tz); 
 
@@ -330,7 +332,7 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
             lastY = stack_2.y; stack_2 = stack_1; 
             top--; 
 
-            if (stack_2.y != INFINITY) {
+            if (stack_2.y != PBA_INFINITY) {
                 p = stack[TOID(tx, stack_2.y, tz, size)]; 
                 DECODE(p, stack_1.x, stack_1.y, stack_1.z); 
             }
@@ -339,7 +341,7 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
         // Update pointers to link the current node to the stack
         stack[id] = ENCODE(current.x, lastY, current.z); 
 
-        if (lastY != INFINITY) 
+        if (lastY != PBA_INFINITY) 
             forward[TOID(tx, lastY, tz, size)] = firstY; 
 
         top = max(1, top + 1); 
@@ -348,7 +350,7 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
         stack_1 = stack_2; stack_2 = make_int3(current.x, lastY, current.z); lastY = firstY; 
         firstY = tex1Dfetch(pbaTexPointer, id); 
 
-        if (firstY != INFINITY) {
+        if (firstY != PBA_INFINITY) {
             id = TOID(tx, firstY, tz, size); 
             p = tex1Dfetch(pbaTexLinks, id); 
             DECODE(p, current.x, current.y, current.z); 
@@ -359,7 +361,7 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
     firstY = band1 * bandSize; 
     lastY = band2 * bandSize; 
 
-    if (tex1Dfetch(pbaTexPointer, TOID(tx, firstY, tz, size)) == -INFINITY) 
+    if (tex1Dfetch(pbaTexPointer, TOID(tx, firstY, tz, size)) == -PBA_INFINITY) 
         forward[TOID(tx, firstY, tz, size)] = -fabsf(tex1Dfetch(pbaTexPointer, TOID(tx, lastY, tz, size))); 
 
     // Update the tail pointer
@@ -369,11 +371,11 @@ __global__ void kernelMergeBands(int *stack, short *forward, int size, int mod, 
     p = tex1Dfetch(pbaTexLinks, TOID(tx, lastY, tz, size)); 
     DECODE(p, current.x, current.y, current.z); 
 
-    if (current.x == INFINITY && current.y == INFINITY) {
+    if (current.x == PBA_INFINITY && current.y == PBA_INFINITY) {
         p = tex1Dfetch(pbaTexLinks, TOID(tx, firstY, tz, size)); 
         DECODE(p, stack_1.x, stack_1.y, stack_1.z); 
 
-        if (stack_1.x == INFINITY) 
+        if (stack_1.x == PBA_INFINITY) 
             current.y = stack_1.y; 
         else
             current.y = firstY; 
@@ -391,13 +393,13 @@ __global__ void kernelCreateForwardPointers(short *output, int size, int mod, in
     int ty = (band+1) * bandSize - 1; 
     int tz = blockIdx.y * blockDim.y + threadIdx.y; 
 
-    int lasty = INFINITY, nexty; 
+    int lasty = PBA_INFINITY, nexty; 
     int current, id; 
 
     // Get the tail pointer
     current = tex1Dfetch(pbaTexLinks, TOID(tx, ty, tz, size)); 
 
-    if (GET_X(current) == INFINITY) 
+    if (GET_X(current) == PBA_INFINITY) 
         nexty = GET_Y(current); 
     else
         nexty = ty; 
@@ -437,16 +439,16 @@ __global__ void kernelColorAxis(int *output, int size)
         p = tex1Dfetch(pbaTexColor, TOID(tx, lastY, tz, size)); 
         DECODE(p, stack_2.x, stack_2.y, stack_2.z); 
 
-        if (stack_2.x == INFINITY) {     // Not a site
+        if (stack_2.x == PBA_INFINITY) {     // Not a site
             lastY = stack_2.y; 
 
-            if (lastY != INFINITY) {
+            if (lastY != PBA_INFINITY) {
                 p = tex1Dfetch(pbaTexColor, TOID(tx, lastY, tz, size)); 
                 DECODE(p, stack_2.x, stack_2.y, stack_2.z); 
             }
         }
 
-        if (stack_2.y != INFINITY) { 
+        if (stack_2.y != PBA_INFINITY) { 
             p = tex1Dfetch(pbaTexColor, TOID(tx, stack_2.y, tz, size)); 
             DECODE(p, stack_1.x, stack_1.y, stack_1.z); 
             ii = interpointY(stack_1.x, stack_2.y, stack_1.z, stack_2.x, lastY, stack_2.z, tx, tz); 
@@ -460,13 +462,13 @@ __global__ void kernelColorAxis(int *output, int size)
     for (int ty = size - 1 - tid; ty >= 0; ty -= blockDim.y) {
         stack_1 = s_Stack1[col]; stack_2 = s_Stack2[col]; lastY = s_lastY[col]; ii = s_ii[col]; 
 
-        while (stack_2.y != INFINITY) {
+        while (stack_2.y != PBA_INFINITY) {
             if (ty > ii) 
                 break; 
 
             lastY = stack_2.y; stack_2 = stack_1;
 
-            if (stack_2.y != INFINITY) {
+            if (stack_2.y != PBA_INFINITY) {
                 p = tex1Dfetch(pbaTexColor, TOID(tx, stack_2.y, tz, size)); 
                 DECODE(p, stack_1.x, stack_1.y, stack_1.z); 
 


### PR DESCRIPTION
## Summary
- Update CMake to build with CUDA 12 and C++14
- Replace deprecated Thrust and texture APIs for compatibility with modern CUDA
- Fix build by linking Shewchuk predicates and using direct memory access

## Testing
- `cmake .. && make -j2`
- `./greg3d` *(fails: no CUDA-capable device detected)*

------
https://chatgpt.com/codex/tasks/task_b_68bdcecf28a08326a241874162e8edcd