### PR TITLE
Include required headers in GDelaunay interface

### DIFF
--- a/GDelaunay/GDelaunay/GDelaunay.h
+++ b/GDelaunay/GDelaunay/GDelaunay.h
@@ -36,6 +36,10 @@ DAMAGE.
 
 #pragma once
 
+// Project headers
+#include "Config.h"
+#include "Geometry.h"
+
 void gdelInit( const Config&, const Point3HVec&, const WeightHVec& );
 void gdelDeInit();
 void gdelCompute( double&, double&, double&, double& );


### PR DESCRIPTION
## Summary
- include Config and Geometry headers in GDelaunay.h so types like Point3HVec and TetraMesh are visible

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc. Compiler requires the CUDA toolkit. Please set the CUDAToolkit_ROOT variable.)*


------
https://chatgpt.com/codex/tasks/task_b_68be815fcb148326a293a1105c07acae