### PR TITLE
Fix EdgesWeightedDelaunay3D build by removing Application.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_executable(greg3d ${GREG3D_SOURCE_FILES})
 target_link_libraries(greg3d PRIVATE CUDA::cudart)
 
 set(EDGES_SOURCE_FILES ${GREG3D_SOURCE_FILES})
-list(REMOVE_ITEM EDGES_SOURCE_FILES GDelaunay/Main/Main.cpp)
+list(REMOVE_ITEM EDGES_SOURCE_FILES GDelaunay/Main/Main.cpp GDelaunay/Main/Application.cpp)
 list(APPEND EDGES_SOURCE_FILES GDelaunay/Main/EdgesWeightedDelaunay3D.cpp)
 add_executable(EdgesWeightedDelaunay3D ${EDGES_SOURCE_FILES})
 target_link_libraries(EdgesWeightedDelaunay3D PRIVATE CUDA::cudart)


### PR DESCRIPTION
## Summary
- Remove Application.cpp from the EdgesWeightedDelaunay3D target to avoid undefined reference to `getConfig`

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_b_68be8db305a08326a2ef6aa4c0b0a5a7